### PR TITLE
Add user data response in login with jwt

### DIFF
--- a/src/main/java/com/diplomado/controller/AuthController.java
+++ b/src/main/java/com/diplomado/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.diplomado.controller;
 import com.diplomado.model.ApiResponse;
 import com.diplomado.model.JwtResponse;
 import com.diplomado.model.Usuario;
+import com.diplomado.model.dto.UsuarioDTO;
 import com.diplomado.security.JwtTokenProvider;
 import com.diplomado.service.UsuarioService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,17 +51,20 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<JwtResponse>> authenticateUser(@RequestBody Usuario user) {
-        // Autenticar al usuario con correo y contraseña
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(user.getCorreo(), user.getContrasena()));
 
-        // Generar el token JWT
         String token = tokenProvider.generateToken(authentication.getName());
 
-        // Crear el modelo de respuesta JWT
-        JwtResponse jwtResponse = new JwtResponse(token);
+        Usuario usuarioAutenticado = userService.findByCorreo(authentication.getName())
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
 
-        // Crear el modelo de respuesta estándar
+        // Convertir Usuario a UsuarioDTO para no exponer la contraseña
+        UsuarioDTO usuarioDTO = userService.convertirAUsuarioDTO(usuarioAutenticado);
+
+        // Crear el modelo de respuesta JWT con el token y el usuarioDTO
+        JwtResponse jwtResponse = new JwtResponse(token, usuarioDTO);
+
         ApiResponse<JwtResponse> response = new ApiResponse<>("success", "Inicio de sesión exitoso", jwtResponse);
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/diplomado/model/JwtResponse.java
+++ b/src/main/java/com/diplomado/model/JwtResponse.java
@@ -1,23 +1,32 @@
 package com.diplomado.model;
 
+import com.diplomado.model.dto.UsuarioDTO;
+
 public class JwtResponse {
     private String token; // Token JWT generado
+    private UsuarioDTO usuario; // Información del usuario sin la contraseña
 
-    // Constructor vacío
     public JwtResponse() {
     }
 
-    // Constructor con parámetros
-    public JwtResponse(String token) {
+    public JwtResponse(String token, UsuarioDTO usuario) {
         this.token = token;
+        this.usuario = usuario;
     }
 
-    // Getters y Setters
     public String getToken() {
         return token;
     }
 
     public void setToken(String token) {
         this.token = token;
+    }
+
+    public UsuarioDTO getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(UsuarioDTO usuario) {
+        this.usuario = usuario;
     }
 }

--- a/src/main/java/com/diplomado/model/dto/UsuarioDTO.java
+++ b/src/main/java/com/diplomado/model/dto/UsuarioDTO.java
@@ -1,0 +1,10 @@
+package com.diplomado.model.dto;
+
+import lombok.Data;
+
+@Data
+public class UsuarioDTO {
+    private int idUsuario;
+    private String nombre;
+    private String correo;
+}

--- a/src/main/java/com/diplomado/service/UsuarioService.java
+++ b/src/main/java/com/diplomado/service/UsuarioService.java
@@ -1,5 +1,6 @@
 package com.diplomado.service;
 import com.diplomado.model.Usuario;
+import com.diplomado.model.dto.UsuarioDTO;
 import com.diplomado.repository.UsuarioRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -35,5 +36,13 @@ public class UsuarioService implements UserDetailsService {
                 .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado con el correo: " + correo));
 
         return new User(usuario.getCorreo(), usuario.getContrasena(), Collections.emptyList());
+    }
+
+    public UsuarioDTO convertirAUsuarioDTO(Usuario usuario) {
+        UsuarioDTO dto = new UsuarioDTO();
+        dto.setIdUsuario(usuario.getIdUsuario());
+        dto.setNombre(usuario.getNombre());
+        dto.setCorreo(usuario.getCorreo());
+        return dto;
     }
 }


### PR DESCRIPTION
This pull request includes several changes to enhance the security and structure of the authentication process by introducing a `UsuarioDTO` to avoid exposing sensitive user information. The main changes involve updating the `AuthController`, modifying the `JwtResponse` class, and adding a new `UsuarioDTO` class.

### Enhancements to Authentication Process:

* [`src/main/java/com/diplomado/controller/AuthController.java`](diffhunk://#diff-4ed937c6f4f085a7da1e5a64c2957953f4693ffb7d72115948c8fbbcdbde355bR6): Introduced `UsuarioDTO` to avoid exposing user passwords in the response. Updated `authenticateUser` method to convert `Usuario` to `UsuarioDTO` and include it in the `JwtResponse`. [[1]](diffhunk://#diff-4ed937c6f4f085a7da1e5a64c2957953f4693ffb7d72115948c8fbbcdbde355bR6) [[2]](diffhunk://#diff-4ed937c6f4f085a7da1e5a64c2957953f4693ffb7d72115948c8fbbcdbde355bL53-L63)

### Modifications to Response Models:

* [`src/main/java/com/diplomado/model/JwtResponse.java`](diffhunk://#diff-c8eadc6660af0e2cd1bac9ce8b307ec5e01fcd66290c5922bdfae76b158872aeR3-R31): Added `UsuarioDTO` to the `JwtResponse` class and updated the constructor and getter/setter methods accordingly.

### New Data Transfer Object:

* [`src/main/java/com/diplomado/model/dto/UsuarioDTO.java`](diffhunk://#diff-1580fb7cc220bf3a6b0acea907826dd658b98b12a9a37c3b3aec8bdbf66d4227R1-R10): Created a new `UsuarioDTO` class to hold user information without the password.

### Service Layer Updates:

* [`src/main/java/com/diplomado/service/UsuarioService.java`](diffhunk://#diff-82dce5ddd45f67a1effc82b2c4fbf87cc9bc2ad693958ed4be111d58665cd36aR3): Added a method to convert `Usuario` to `UsuarioDTO`. [[1]](diffhunk://#diff-82dce5ddd45f67a1effc82b2c4fbf87cc9bc2ad693958ed4be111d58665cd36aR3) [[2]](diffhunk://#diff-82dce5ddd45f67a1effc82b2c4fbf87cc9bc2ad693958ed4be111d58665cd36aR40-R47)